### PR TITLE
Add GDPR compliant analytics

### DIFF
--- a/public/holding/index.php
+++ b/public/holding/index.php
@@ -28,6 +28,7 @@
     <link rel="icon" href="/img/favicon/favicon-32.png" sizes="32x32">
     <link rel="icon" href="/img/favicon/favicon-16.png" sizes="16x16">
     <link href="/favicon.ico" rel="shortcut icon">
+    <?php include '../tpl/matomo.php' ?>
   </head>
   <body>
     <div class="wrapper">

--- a/public/index.php
+++ b/public/index.php
@@ -28,6 +28,7 @@
     <link rel="icon" href="/img/favicon/favicon-32.png" sizes="32x32">
     <link rel="icon" href="/img/favicon/favicon-16.png" sizes="16x16">
     <link href="/favicon.ico" rel="shortcut icon">
+    <?php include 'tpl/matomo.php' ?>
   </head>
   <body>
     <div class="vertical-layout">

--- a/public/tpl/matomo.php
+++ b/public/tpl/matomo.php
@@ -1,0 +1,14 @@
+<?php $matomo_site_id = 11; ?>
+<script>
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://matomo.bilaal.co.uk/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '<?php echo $matomo_site_id ?>']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://matomo.bilaal.co.uk/matomo.php?idsite=<?php echo $matomo_site_id; ?>&amp;rec=1" style="border:0;" alt="" /></p></noscript>


### PR DESCRIPTION
# Related issues

Closes #27

# Summary of changes

- Add Matomo analytics to non-admin webapges

# Summary of testing

- Tested Matomo integration code appears and functions correctly locally.

# Steps required for deployment

- Setup Matomo site on matomo.bilaal.co.uk with ID 11
- Deploy MR
