### PR TITLE
Export map to image

### DIFF
--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -57,7 +57,7 @@
 				</div>
 				<div>
 					<h1>Export Data</h1>
-					<p>Download all the data from this event as a zip file. This is a great way to archive the results from past events so they can be kept for future record. If you're resetting for a new event, it would be a good idea to download this data and store it somewhere permanent.</p>
+					<p>Download all the data from this event as a zip file. This is a great way to archive the results from past events so they can be kept for future record. If you're resetting for a new event, it would be a good idea to download this data and store it somewhere permanent. You can also download an image of the <a href="/">map</a> by hovering over the download button and clicking the icon that appears.</p>
 					<a href="/api/export.php" class="link-button">Download Data</a>
 				</div>
 			</div>

--- a/public/index.php
+++ b/public/index.php
@@ -52,6 +52,7 @@
       </div>
     </div>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="https://cdn.jsdelivr.net/npm/leaflet-easyprint@2.1.9/dist/bundle.min.js"></script>
     <script src="/js/constants.js"></script>
     <script src="/js/map.js"></script>
     <script src="/js/config.js"></script>

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -9,6 +9,14 @@ L.control.zoom({
   position: 'bottomleft'
 }).addTo(map);
 
+L.easyPrint({
+  sizeModes: ['A4Landscape'],
+  filename: 'rag-lost',
+  exportOnly: true,
+  hideControlContainer: true,
+	position: 'bottomright',
+}).addTo(map);
+
 const getTimeFromDateString = (timestamp) => {
   const date = new Date(timestamp);
   return `${date.getHours().toLocaleString('en-gb', { minimumIntegerDigits: 2 })}:${date.getMinutes().toLocaleString('en-gb', { minimumIntegerDigits: 2 })}`


### PR DESCRIPTION
# Related issues

Closes #29 

# Summary of changes

- Add a download button to the map to export as an image
- Add a description of the functionality in the admin panel

# Summary of testing

- Tested image export locally in Safari and Chrome

# Steps required for deployment

n/a
